### PR TITLE
Bump versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<encoding>UTF-8</encoding>
 
-		<sansa.version>0.4.0</sansa.version>
+		<sansa.rdf.version>0.5.0</sansa.rdf.version>
 		<sansa.datalake.version>0.0.1-SNAPSHOT</sansa.datalake.version>
 
 		<scala.version>2.11.11</scala.version>
@@ -32,11 +32,11 @@
 
 		<scala.version.suffix>_${scala.binary.version}</scala.version.suffix>
 
-		<spark.version>2.3.1</spark.version>
-		<flink.version>1.5.0</flink.version>
+		<spark.version>2.4.0</spark.version>
+		<flink.version>1.7.0</flink.version>
 
-		<jena.version>3.7.0</jena.version>
-		<jsa.subversion>3</jsa.subversion>
+		<jena.version>3.9.0</jena.version>
+		<jsa.subversion>1</jsa.subversion>
 
 		<jsa.version>${jena.version}-${jsa.subversion}</jsa.version>
 		<scalastyle.config.path>${project.basedir}/scalastyle-config.xml</scalastyle.config.path>
@@ -212,19 +212,19 @@
 			<dependency>
 				<groupId>${project.groupId}</groupId>
 				<artifactId>sansa-rdf-common${scala.version.suffix}</artifactId>
-				<version>${sansa.version}</version>
+				<version>${sansa.rdf.version}</version>
 			</dependency>
 
 			<dependency>
 				<groupId>${project.groupId}</groupId>
 				<artifactId>sansa-rdf-spark${scala.version.suffix}</artifactId>
-				<version>${sansa.version}</version>
+				<version>${sansa.rdf.version}</version>
 			</dependency>
 
 			<dependency>
 				<groupId>${project.groupId}</groupId>
 				<artifactId>sansa-rdf-flink${scala.version.suffix}</artifactId>
-				<version>${sansa.version}</version>
+				<version>${sansa.rdf.version}</version>
 			</dependency>
 
 
@@ -305,6 +305,12 @@
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
 				<version>19.0</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>1.18</version>
 			</dependency>
 
 			<dependency>

--- a/sansa-query-flink/src/main/scala/net/sansa_stack/query/flink/sparqlify/BasicTableInfoProviderFlink.scala
+++ b/sansa-query-flink/src/main/scala/net/sansa_stack/query/flink/sparqlify/BasicTableInfoProviderFlink.scala
@@ -12,7 +12,7 @@ import org.apache.flink.table.api.scala.BatchTableEnvironment
 class BasicTableInfoProviderFlink(flinkTable: BatchTableEnvironment)
   extends BasicTableInfoProvider {
   override def getBasicTableInfo(queryString: String): BasicTableInfo = {
-    val table = flinkTable.sql(queryString)
+    val table = flinkTable.sqlQuery(queryString)
     val schema = table.getSchema
     val types = schema.getTypes
     val names = schema.getColumnNames

--- a/sansa-query-flink/src/main/scala/net/sansa_stack/query/flink/sparqlify/QueryExecutionSparqlifyFlink.scala
+++ b/sansa-query-flink/src/main/scala/net/sansa_stack/query/flink/sparqlify/QueryExecutionSparqlifyFlink.scala
@@ -10,7 +10,7 @@ import org.aksw.jena_sparql_api.core.{ QueryExecutionBaseSelect, QueryExecutionF
 import org.aksw.jena_sparql_api.utils.ResultSetUtils
 import org.aksw.sparqlify.core.domain.input.SparqlSqlStringRewrite
 import org.aksw.sparqlify.core.interfaces.SparqlSqlStringRewriter
-import org.apache.flink  .api.java.typeutils.runtime.kryo.KryoSerializer
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala.{ ExecutionEnvironment, _ }
 import org.apache.flink.table.api.scala.{ BatchTableEnvironment, _ }
 import org.apache.flink.types.Row
@@ -45,6 +45,9 @@ class QueryExecutionSparqlifyFlink(
 
   override def getTimeout1(): Long = -1
 
+  override def execJson(): org.apache.jena.atlas.json.JsonArray = throw new UnsupportedOperationException
+  override def execJsonItems(): java.util.Iterator[org.apache.jena.atlas.json.JsonObject] = throw new UnsupportedOperationException
+
 }
 
 object QueryExecutionSparqlifyFlink {
@@ -55,7 +58,7 @@ object QueryExecutionSparqlifyFlink {
 
     println("SQL Query: " + sqlQueryStr)
 
-    val dataset = flinkTable.sql(sqlQueryStr)
+    val dataset = flinkTable.sqlQuery(sqlQueryStr)
     // System.out.println("SqlQueryStr: " + sqlQueryStr);
     // System.out.println("VarDef: " + rewrite.getVarDefinition());
     val rowMapper = new FlinkRowMapperSparqlify(varDef, dataset.getSchema.getColumnNames)

--- a/sansa-query-spark/src/main/java/net/sansa_stack/query/spark/sparqlify/QueryExecutionSparqlifySpark.java
+++ b/sansa-query-spark/src/main/java/net/sansa_stack/query/spark/sparqlify/QueryExecutionSparqlifySpark.java
@@ -9,6 +9,8 @@ import org.aksw.jena_sparql_api.core.ResultSetCloseable;
 import org.aksw.jena_sparql_api.utils.ResultSetUtils;
 import org.aksw.sparqlify.core.domain.input.SparqlSqlStringRewrite;
 import org.aksw.sparqlify.core.interfaces.SparqlSqlStringRewriter;
+import org.apache.jena.atlas.json.JsonArray;
+import org.apache.jena.atlas.json.JsonObject;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.ResultSet;
@@ -17,43 +19,47 @@ import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.SparkSession;
 
-public class QueryExecutionSparqlifySpark
-    extends QueryExecutionBaseSelect
-{
-    public QueryExecutionSparqlifySpark(
-            Query query,
-            QueryExecutionFactory subFactory,
-            SparkSession sparkSession,
-            SparqlSqlStringRewriter sparqlSqlRewriter
-            ) {
-        super(query, subFactory);
-        this.sparkSession = sparkSession;
-        this.sparqlSqlRewriter = sparqlSqlRewriter;
-    }
+public class QueryExecutionSparqlifySpark extends QueryExecutionBaseSelect {
+	public QueryExecutionSparqlifySpark(Query query, QueryExecutionFactory subFactory, SparkSession sparkSession,
+			SparqlSqlStringRewriter sparqlSqlRewriter) {
+		super(query, subFactory);
+		this.sparkSession = sparkSession;
+		this.sparqlSqlRewriter = sparqlSqlRewriter;
+	}
 
-    protected SparkSession sparkSession;
-    protected SparqlSqlStringRewriter sparqlSqlRewriter;
+	protected SparkSession sparkSession;
+	protected SparqlSqlStringRewriter sparqlSqlRewriter;
 
-    @Override
-    protected ResultSetCloseable executeCoreSelect(Query query) {
-        SparqlSqlStringRewrite rewrite = sparqlSqlRewriter.rewrite(query);
-        List<Var> resultVars = rewrite.getProjectionOrder();
+	@Override
+	protected ResultSetCloseable executeCoreSelect(Query query) {
+		SparqlSqlStringRewrite rewrite = sparqlSqlRewriter.rewrite(query);
+		List<Var> resultVars = rewrite.getProjectionOrder();
 
-        JavaRDD<Binding> rdd = QueryExecutionUtilsSpark.createQueryExecution(sparkSession, rewrite, query);
-        Iterator<Binding> it = rdd.toLocalIterator();
+		JavaRDD<Binding> rdd = QueryExecutionUtilsSpark.createQueryExecution(sparkSession, rewrite, query);
+		Iterator<Binding> it = rdd.toLocalIterator();
 
-        ResultSet tmp = ResultSetUtils.create2(resultVars, it);
-        ResultSetCloseable result = new ResultSetCloseable(tmp);
-        return result;
-    }
+		ResultSet tmp = ResultSetUtils.create2(resultVars, it);
+		ResultSetCloseable result = new ResultSetCloseable(tmp);
+		return result;
+	}
 
-    @Override
-    protected QueryExecution executeCoreSelectX(Query query) {
-        throw new UnsupportedOperationException();
-    }
+	@Override
+	protected QueryExecution executeCoreSelectX(Query query) {
+		throw new UnsupportedOperationException();
+	}
 
-    @Override
-    public long getTimeout1() {
-        return -1;
-    }
+	@Override
+	public long getTimeout1() {
+		return -1;
+	}
+
+	@Override
+	public JsonArray execJson() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Iterator<JsonObject> execJsonItems() {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/sansa-query-spark/src/main/scala/net/sansa_stack/query/spark/package.scala
+++ b/sansa-query-spark/src/main/scala/net/sansa_stack/query/spark/package.scala
@@ -67,34 +67,12 @@ package object query {
 
   implicit class Semantic(partitions: RDD[String]) extends Serializable {
 
-    val symbol = Map(
-      "space" -> " " * 5,
-      "blank" -> " ",
-      "tabs" -> "\t",
-      "newline" -> "\n",
-      "colon" -> ":",
-      "comma" -> ",",
-      "hash" -> "#",
-      "slash" -> "/",
-      "question-mark" -> "?",
-      "exclamation-mark" -> "!",
-      "curly-bracket-left" -> "{",
-      "curly-bracket-right" -> "}",
-      "round-bracket-left" -> "(",
-      "round-bracket-right" -> ")",
-      "less-than" -> "<",
-      "greater-than" -> ">",
-      "at" -> "@",
-      "dot" -> ".",
-      "dots" -> "...",
-      "asterisk" -> "*",
-      "up-arrows" -> "^^")
-
     /**
      * semantic partition of and RDF graph
      */
     def sparql(sparqlQuery: String)(input: String, output: String, numOfFilesPartition: Int): Unit = {
-      new QuerySystem(symbol, partitions,
+      new QuerySystem(
+        partitions,
         input,
         output,
         numOfFilesPartition).run()

--- a/sansa-query-spark/src/main/scala/net/sansa_stack/query/spark/semantic/SparqlQuerySystem.scala
+++ b/sansa-query-spark/src/main/scala/net/sansa_stack/query/spark/semantic/SparqlQuerySystem.scala
@@ -11,19 +11,18 @@ import scala.util.Try
 
 import com.google.common.collect.ArrayListMultimap
 import net.sansa_stack.query.spark.semantic.utils.Helpers._
+import net.sansa_stack.rdf.common.partition.utils.Symbols
 import org.apache.spark.rdd._
 
 /*
  * QuerySystem - query on semantic partition data
  *
- * @symbol - list of symbols.
  * @partitionData - a RDD of n-triples (formatted).
  * @queryInputPath - query file path.
  * @queryResultPath - path for output result.
  * @numOfFilesPartition - total number of files to save the partition data.
  */
 class QuerySystem(
-  symbol: Map[String, String],
   partitionData: RDD[String],
   queryInputPath: String,
   queryResultPath: String,
@@ -40,6 +39,7 @@ class QuerySystem(
   var workingTripleRDD: RDD[(String, List[String])] = _
   var workingPartialRDD: RDD[(String, List[String])] = _
   var unionOutputRDD: RDD[String] = _
+  val symbol = Symbols.symbol
 
   def run(): Unit = {
     // parse queries


### PR DESCRIPTION
This PR bump versions for : 
- sansa.rdf:0.5.0, 
- spark:2.4.0, 
- flink:1.7.0,
- jena:3.9.0

and align some Flink implementation related to the version change. There are also some cleanups for semantic-based query engine.

Best,