### PR TITLE
Hotfix: semantic query engine

### DIFF
--- a/sansa-query-spark/src/main/scala/net/sansa_stack/query/spark/package.scala
+++ b/sansa-query-spark/src/main/scala/net/sansa_stack/query/spark/package.scala
@@ -29,6 +29,7 @@ package object query {
     val spark = SparkSession.builder().getOrCreate()
     /**
      * Default partition - using VP.
+     * @param sparqlQuery a SPARQL query
      */
     def sparql(sparqlQuery: String): DataFrame = {
       val partitions = triples.partitionGraph()
@@ -48,6 +49,7 @@ package object query {
     val spark = SparkSession.builder().getOrCreate()
     /**
      * Default partition - using VP.
+     * @param sparqlQuery a SPARQL query
      */
     def sparql(sparqlQuery: String): DataFrame = {
       val rewriter = SparqlifyUtils3.createSparqlSqlRewriter(spark, partitions)
@@ -69,14 +71,13 @@ package object query {
   implicit class Semantic(partitions: RDD[String]) extends Serializable {
 
     /**
-     * semantic partition of and RDF graph
+     * Semantic partition of and RDF graph
+     * @param queryInputPath -- a path to the SPARQL queries.
      */
-    def sparql(sparqlQuery: String)(input: String, output: String, numOfFilesPartition: Int): Unit = {
+    def sparql(queryInputPath: String): RDD[String] = {
       new QuerySystem(
         partitions,
-        input,
-        output,
-        numOfFilesPartition).run()
+        queryInputPath).run()
     }
 
   }

--- a/sansa-query-spark/src/main/scala/net/sansa_stack/query/spark/semantic/SparqlQuerySystem.scala
+++ b/sansa-query-spark/src/main/scala/net/sansa_stack/query/spark/semantic/SparqlQuerySystem.scala
@@ -23,7 +23,7 @@ import org.apache.spark.rdd._
  * @numOfFilesPartition - total number of files to save the partition data.
  */
 class QuerySystem(
-  partitionData:  RDD[String],
+  partitionData: RDD[String],
   queryInputPath: String)
   extends Serializable {
   var _selectVariables: Map[Int, ArrayBuffer[String]] = Map()
@@ -1203,13 +1203,13 @@ class QuerySystem(
   // FILTER comparison
   def filterComparison(a: String, b: String, operator: String): Boolean = {
     val result: Boolean = operator match {
-      case "<"        => a < b
-      case ">"        => a > b
+      case "<" => a < b
+      case ">" => a > b
       case "=" | "==" => a.equals(b)
-      case ">="       => a > b || a.equals(b)
-      case "<="       => a < b || a.equals(b)
-      case "!="       => !a.equals(b)
-      case _          => throw new IllegalStateException(s"FILTER - Wrong Operator Found: $operator")
+      case ">=" => a > b || a.equals(b)
+      case "<=" => a < b || a.equals(b)
+      case "!=" => !a.equals(b)
+      case _ => throw new IllegalStateException(s"FILTER - Wrong Operator Found: $operator")
     }
 
     result

--- a/sansa-query-spark/src/main/scala/net/sansa_stack/query/spark/semantic/SparqlQuerySystem.scala
+++ b/sansa-query-spark/src/main/scala/net/sansa_stack/query/spark/semantic/SparqlQuerySystem.scala
@@ -63,13 +63,7 @@ class QuerySystem(
         // query engine
         this.queryEngine(qID)
       }
-
-      // end process time
-      _queriesProcessTime.append(queryTime((System.nanoTime() - startTime), symbol))
     }
-
-    // overall process time
-    overallQueriesTime(_queriesProcessTime)
     outputRDD
   }
 
@@ -482,20 +476,11 @@ class QuerySystem(
 
   // query engine
   def queryEngine(qID: Int): Unit = {
-    if (_unionOp(qID)("first")) {
-      if (_unionOp(qID)("first").equals(_unionOp(qID)("last"))) println(s"Query No: ${qID + 1}")
-      else println(s"Query No: ${qID + 1} - UNION")
-    }
-
     // validate number of WHERE clause triples
     if (_numOfWhereClauseTriples(qID).equals(1)) {
-      println("No. of WHERE clause Triples: 1")
-
       // process first triple
       this.runFirstTriple(qID)
     } else {
-      println(s"No. of WHERE clause Triples: ${_numOfWhereClauseTriples(qID)}")
-
       // process all triples of a query
       this.runAllTriplesOfQuery(qID)
     }
@@ -655,7 +640,6 @@ class QuerySystem(
           else unionOutputRDD = unionOutputRDD.union(outputRDD)
         }
 
-        outputRDD.take(5).foreach(println)
         // display output
         if (_unionOp(qID)("last")) {
 

--- a/sansa-query-spark/src/test/resources/queries/bsbm/Q1.sparql
+++ b/sansa-query-spark/src/test/resources/queries/bsbm/Q1.sparql
@@ -1,0 +1,4 @@
+SELECT ?X
+WHERE {
+    ?X <http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/vocabulary/productFeature> <http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/instances/ProductFeature40> .
+}

--- a/sansa-query-spark/src/test/resources/queries/bsbm/Q2.sparql
+++ b/sansa-query-spark/src/test/resources/queries/bsbm/Q2.sparql
@@ -1,0 +1,4 @@
+SELECT ?X
+WHERE {
+    ?X :subClassOf <http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/instances/ProductType2> .
+}

--- a/sansa-query-spark/src/test/resources/queries/bsbm/Q3.sparql
+++ b/sansa-query-spark/src/test/resources/queries/bsbm/Q3.sparql
@@ -1,0 +1,5 @@
+SELECT ?X ?Y
+WHERE {
+    ?X :type <http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/instances/ProductType3> .
+    ?X <http://www4.wiwiss.fu-berlin.de/bizer/bsbm/v01/vocabulary/productFeature> ?Y .
+}

--- a/sansa-query-spark/src/test/scala/net/sansa_stack/query/spark/semantic/SemanticQueryEngineTests.scala
+++ b/sansa-query-spark/src/test/scala/net/sansa_stack/query/spark/semantic/SemanticQueryEngineTests.scala
@@ -1,0 +1,58 @@
+package net.sansa_stack.query.spark.semantic
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.scalatest.FunSuite
+import org.apache.jena.riot.Lang
+
+import net.sansa_stack.rdf.spark.io._
+import net.sansa_stack.rdf.spark.partition._
+
+class SemanticQueryEngineTests extends FunSuite with DataFrameSuiteBase {
+
+  import net.sansa_stack.query.spark.query._
+
+  test("result of running BSBM Q1 should match") {
+
+    val input = getClass.getResource("/datasets/bsbm-sample.nt").getPath
+    val query = getClass.getResource("/queries/bsbm/Q1.sparql").getPath
+    val triples = spark.rdf(Lang.NTRIPLES)(input)
+
+    val partitionTriples = triples.partitionGraphAsSemantic()
+
+    val result = partitionTriples.sparql(query)
+
+    val size = result.count()
+
+    assert(size == 7)
+  }
+
+  test("result of running BSBM Q2 should match") {
+
+    val input = getClass.getResource("/datasets/bsbm-sample.nt").getPath
+    val query = getClass.getResource("/queries/bsbm/Q2.sparql").getPath
+    val triples = spark.rdf(Lang.NTRIPLES)(input)
+
+    val partitionTriples = triples.partitionGraphAsSemantic()
+
+    val result = partitionTriples.sparql(query)
+
+    val size = result.count()
+
+    assert(size == 4)
+  }
+
+  test("result of running BSBM Q3 should match") {
+
+    val input = getClass.getResource("/datasets/bsbm-sample.nt").getPath
+    val query = getClass.getResource("/queries/bsbm/Q3.sparql").getPath
+    val triples = spark.rdf(Lang.NTRIPLES)(input)
+
+    val partitionTriples = triples.partitionGraphAsSemantic()
+
+    val result = partitionTriples.sparql(query)
+
+    val size = result.count()
+
+    assert(size == 674)
+  }
+}

--- a/sansa-query-spark/src/test/scala/net/sansa_stack/query/spark/semantic/SemanticQueryEngineTests.scala
+++ b/sansa-query-spark/src/test/scala/net/sansa_stack/query/spark/semantic/SemanticQueryEngineTests.scala
@@ -1,11 +1,10 @@
 package net.sansa_stack.query.spark.semantic
 
 import com.holdenkarau.spark.testing.DataFrameSuiteBase
-import org.scalatest.FunSuite
-import org.apache.jena.riot.Lang
-
 import net.sansa_stack.rdf.spark.io._
 import net.sansa_stack.rdf.spark.partition._
+import org.apache.jena.riot.Lang
+import org.scalatest.FunSuite
 
 class SemanticQueryEngineTests extends FunSuite with DataFrameSuiteBase {
 


### PR DESCRIPTION
Hi SANSA Query team,

this **hot** fix resolves the issue of not returning the result set when we run SPARQL queries over Semantic-based query engine implemented into SANSA.

This PR fixes issue #22  and partially issue #23 
Regarding issue #23, the query posted there contains variable into BGP (?s **?p** ?o), therefore, it is not supported by the semantic query engine (yet).
We plan to work on it when we plug-in our approach using the Jena ARQ API.

Best regards,
