### PR TITLE
Scala 2.12 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<parent>
 		<groupId>net.sansa-stack</groupId>
-		<artifactId>sansa-parent</artifactId>
+		<artifactId>sansa-parent_2.11</artifactId>
 		<version>0.7.2-SNAPSHOT</version>
 	</parent>
 

--- a/sansa-query-flink/src/main/scala/net/sansa_stack/query/flink/sparqlify/QueryExecutionSparqlifyFlink.scala
+++ b/sansa-query-flink/src/main/scala/net/sansa_stack/query/flink/sparqlify/QueryExecutionSparqlifyFlink.scala
@@ -10,6 +10,7 @@ import org.aksw.jena_sparql_api.core.{QueryExecutionBaseSelect, QueryExecutionFa
 import org.aksw.jena_sparql_api.utils.ResultSetUtils
 import org.aksw.sparqlify.core.domain.input.SparqlSqlStringRewrite
 import org.aksw.sparqlify.core.interfaces.SparqlSqlStringRewriter
+import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala.{ExecutionEnvironment, _}
 import org.apache.flink.table.api.scala.{BatchTableEnvironment, _}
@@ -79,6 +80,8 @@ object QueryExecutionSparqlifyFlink {
     println("byte size=" + bytes.length)
     println(util.Arrays.toString(bytes))
     dataset.printSchema()
+
+    implicit val typeInfo = TypeInformation.of(classOf[Row])
     val result = dataset.toDataSet[Row].map(row => {
       val kryo = new KryoSerializer[FlinkRowMapperSparqlify](classOf[FlinkRowMapperSparqlify], config).getKryo
 

--- a/sansa-query-flink/src/main/scala/net/sansa_stack/query/flink/sparqlify/SparqlifyUtils3.scala
+++ b/sansa-query-flink/src/main/scala/net/sansa_stack/query/flink/sparqlify/SparqlifyUtils3.scala
@@ -1,7 +1,9 @@
 package net.sansa_stack.query.flink.sparqlify
 
 import scala.reflect.runtime.universe.typeOf
+
 import com.typesafe.scalalogging.StrictLogging
+
 import net.sansa_stack.rdf.common.partition.core.RdfPartitionDefault
 import net.sansa_stack.rdf.common.partition.model.sparqlify.SparqlifyUtils2
 import net.sansa_stack.rdf.common.partition.schema._
@@ -12,18 +14,24 @@ import org.aksw.sparqlify.core.interfaces.SparqlSqlStringRewriter
 import org.aksw.sparqlify.core.sql.common.serialization.{SqlEscaperBacktick, SqlEscaperBase, SqlEscaperDoubleQuote}
 import org.aksw.sparqlify.util.{SparqlifyCoreInit, SparqlifyUtils, SqlBackendConfig}
 import org.aksw.sparqlify.validation.LoggerCount
+import org.apache.flink.api.common.functions.MapFunction
 import org.apache.flink.api.scala.{DataSet, ExecutionEnvironment, _}
 import org.apache.flink.table.api.scala.BatchTableEnvironment
+import scala.collection.JavaConverters._
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
 
 object SparqlifyUtils3
   extends StrictLogging {
-  def createSparqlSqlRewriter(flinkEnv: ExecutionEnvironment, flinkTable: BatchTableEnvironment, partitions: Map[RdfPartitionDefault, DataSet[_ <: Product]]): SparqlSqlStringRewriter = {
+
+  def createSparqlSqlRewriter(flinkEnv: ExecutionEnvironment, flinkTable: BatchTableEnvironment,
+                              partitions: Map[RdfPartitionDefault, DataSet[_ <: Product]]): SparqlSqlStringRewriter = {
     val config = new Config()
     val loggerCount = new LoggerCount(logger.underlying)
 
     val backendConfig = new SqlBackendConfig(new DatatypeToStringFlink(), new SqlEscaperBacktick())
-    val sqlEscaper = backendConfig.getSqlEscaper()
-    val typeSerializer = backendConfig.getTypeSerializer()
+    val sqlEscaper = backendConfig.getSqlEscaper
+    val typeSerializer = backendConfig.getTypeSerializer
     val sqlFunctionMapping = SparqlifyCoreInit.loadSqlFunctionDefinitions("functions-spark.xml")
 
     val ers = SparqlifyUtils.createDefaultExprRewriteSystem()
@@ -32,7 +40,7 @@ object SparqlifyUtils3
     val candidateViewSelector = new CandidateViewSelectorSparqlify(mappingOps, new ViewDefinitionNormalizerImpl());
 
     partitions.map {
-      case (p, ds) =>
+      case (p, ds: DataSet[Product]) =>
         logger.debug("Processing RdfPartition: " + p)
         val vd = SparqlifyUtils2.createViewDefinition(p)
         logger.debug("Created view definition: " + vd)
@@ -41,22 +49,52 @@ object SparqlifyUtils3
           case _ => throw new RuntimeException("Table name required - instead got: " + vd)
         }
         val q = p.layout.schema
-        q match {
+//        q match {
+//          case q if q =:= typeOf[SchemaStringLong] =>
+//            var fn = (r: Product) => r.asInstanceOf[SchemaStringLong]
+//            flinkTable.registerDataSet(tableName, ds.map (fn))
+//          case q if q =:= typeOf[SchemaStringString] =>
+//            var fn = (r: Product) => r.asInstanceOf[SchemaStringString]
+//            flinkTable.registerDataSet(tableName, ds.map (fn))
+//          case q if q =:= typeOf[SchemaStringStringType] =>
+//            var fn = (r: Product) => r.asInstanceOf[SchemaStringStringType]
+//            flinkTable.registerDataSet(tableName, ds.map (fn))
+//          case q if q =:= typeOf[SchemaStringDouble] =>
+//            var fn = (r: Product) => r.asInstanceOf[SchemaStringDouble]
+//            flinkTable.registerDataSet(tableName, ds.map (fn))
+//          case q if q =:= typeOf[SchemaStringStringLang] =>
+//            var fn = (r: Product) => r.asInstanceOf[SchemaStringStringLang]
+//            flinkTable.registerDataSet(tableName, ds.map (fn))
+//          case q if q =:= typeOf[SchemaStringDate] =>
+//            var fn = (r: Product) => r.asInstanceOf[SchemaStringDate]
+//            flinkTable.registerDataSet(tableName, ds.map (fn))
+//          case _ =>
+//            throw new RuntimeException("Unhandled schema type: " + q)
+//        }
+
+
+        val fn: Product => Product = q match {
           case q if q =:= typeOf[SchemaStringLong] =>
-            flinkTable.registerDataSet(tableName, ds.map { r => r.asInstanceOf[SchemaStringLong] })
+            (r: Product) => r.asInstanceOf[SchemaStringLong]
           case q if q =:= typeOf[SchemaStringString] =>
-            flinkTable.registerDataSet(tableName, ds.map { r => r.asInstanceOf[SchemaStringString] })
+            (r: Product) => r.asInstanceOf[SchemaStringString]
           case q if q =:= typeOf[SchemaStringStringType] =>
-            flinkTable.registerDataSet(tableName, ds.map { r => r.asInstanceOf[SchemaStringStringType] })
+            (r: Product) => r.asInstanceOf[SchemaStringStringType]
           case q if q =:= typeOf[SchemaStringDouble] =>
-            flinkTable.registerDataSet(tableName, ds.map { r => r.asInstanceOf[SchemaStringDouble] })
+            (r: Product) => r.asInstanceOf[SchemaStringDouble]
           case q if q =:= typeOf[SchemaStringStringLang] =>
-            flinkTable.registerDataSet(tableName, ds.map { r => r.asInstanceOf[SchemaStringStringLang] })
+            (r: Product) => r.asInstanceOf[SchemaStringStringLang]
           case q if q =:= typeOf[SchemaStringDate] =>
-            flinkTable.registerDataSet(tableName, ds.map { r => r.asInstanceOf[SchemaStringDate] })
+            (r: Product) => r.asInstanceOf[SchemaStringDate]
           case _ =>
             throw new RuntimeException("Unhandled schema type: " + q)
         }
+        import org.apache.flink.api.scala._
+//        implicit val typeInfo = TypeInformation.of(classOf[(Product, Product)])
+        flinkTable.registerDataSet(tableName, ds.map (fn))
+//        val newDS = classOf[DataSet[Product]].getMethod("map", classOf[MapFunction[Product, _ <: Product]]).invoke(ds, fn).asInstanceOf[DataSet[Product]]
+//        flinkTable.registerDataSet(tableName, newDS)
+
         config.getViewDefinitions.add(vd)
         (p, vd.getName)
 


### PR DESCRIPTION

* changed name of parent module
* some Spark and Flink code had to be adapted because of ambiguous methods due to Java 8 and Scala interface
